### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A composite action that combines the following steps:
 
-* Set up a JDK with `actions/setup-java@v2`
+* Set up a JDK with `actions/setup-java@v3`
 * Set up a `user.name` system property with `spring-builds+github`
 * Validate the Gradle wrapper using `gradle/wrapper-validation-action@v1`
 * Set up Gradle using `gradle/gradle-build-action@v2` with `GRADLE_USER_HOME=/home/runner/.gradle`
@@ -25,7 +25,7 @@ Accepts the following inputs:
 ## Example Usage
 
 ```yaml
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: spring-io/spring-gradle-build-action@v1
 - name: Run tests
   run: ./gradlew test

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.distribution }}


### PR DESCRIPTION
The save-state, set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/