### PR TITLE
Use cache in action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A composite action that combines the following steps:
 
-* Set up a JDK with `actions/setup-java@v2`
+* Set up a JDK with `actions/setup-java@v3`
 * Set up a `user.name` system property with `spring-builds+github`
 * Validate the Gradle wrapper using `gradle/wrapper-validation-action@v1`
 * Set up Gradle using `gradle/gradle-build-action@v2` with `GRADLE_USER_HOME=/home/runner/.gradle`
@@ -11,6 +11,7 @@ Accepts the following inputs:
 
 * `java-version` (Optional, defaults to `'17'`)
 * `distribution` (Optional, defaults to `'temurin'`)
+* `cache` (Optional, defaults to `'gradle'`)
 
 ## Installation
 
@@ -20,6 +21,7 @@ Accepts the following inputs:
   with:
     java-version: '17'
     distribution: 'temurin'
+    cache: 'gradle'
 ```
 
 ## Example Usage

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,20 @@ inputs:
     description: 'Distribution of the JDK to use to run the Gradle command. Used in the actions/setup-java step.'
     required: false
     default: 'temurin'
+  cache:
+    description: 'Optional input to set up caching for the setup-java action. The input syntax corresponds to the setup-java's one. Set to an empty string if caching isn't needed'
+    required: false
+    default: 'gradle'
 
 runs:
   using: 'composite'
   steps:
     - name: Set up JDK ${{ inputs.java-version }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.distribution }}
+        cache: ${{ inputs.cache }}
     - name: Set up gradle user name
       shell: bash
       run: |


### PR DESCRIPTION
## Description

Updated `action.yml` to cache gradle dependencies.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions

**AS-IS**

```yaml
- name: Set up JDK ${{ inputs.java-version }}
  uses: actions/setup-java@v2
  with:
    java-version: ${{ inputs.java-version }}
    distribution: ${{ inputs.distribution }}
```

**TO-BE**

```yaml
- name: Set up JDK ${{ inputs.java-version }}
  uses: actions/setup-java@v3
  with:
    java-version: ${{ inputs.java-version }}
    distribution: ${{ inputs.distribution }}
    cache: ${{ inputs.cache }}
```

## References
- [actions/cache#java---gradle](https://github.com/actions/cache/blob/main/examples.md#java---gradle)
- [How to build Gradle projects with GitHub Actions](https://tomgregory.com/build-gradle-projects-with-github-actions/#5_Enable_Gradle_caching)
